### PR TITLE
Use regex expressions to parse matches in the file

### DIFF
--- a/LoopingAudioConverter/Options.cs
+++ b/LoopingAudioConverter/Options.cs
@@ -88,23 +88,21 @@ namespace LoopingAudioConverter {
 
 		public LoopOverride? GetLoopOverrides(string filename) {
 			if (File.Exists("loop.txt")) {
-				using (StreamReader sr = new StreamReader("loop.txt")) {
-					string line;
-					while ((line = sr.ReadLine()) != null) {
-						line = Regex.Replace(line, "[ \t]+", " ");
-						if (line.Length > 0 && line[0] != '#' && line.Contains(" ")) {
-							try {
-								int loopStart = int.Parse(line.Substring(0, line.IndexOf(" ")));
-								line = line.Substring(line.IndexOf(" ") + 1);
-								int loopEnd = int.Parse(line.Substring(0, line.IndexOf(" ")));
-								line = line.Substring(line.IndexOf(" ") + 1);
-								if (line == filename)
-									return new LoopOverride { LoopStart = loopStart, LoopEnd = loopEnd };
-							} catch (Exception e) {
-								Console.Error.WriteLine("Could not parse line in loop.txt: " + line + " - " + e.Message);
-							}
+				try {
+					Regex loopExpression = new Regex(@"(?<loopStart>\d+)\s+(?<loopEnd>\d+)\s+(?<fileName>.+)");
+					MatchCollection loopCollection = loopExpression.Matches(File.ReadAllText("loop.txt"));
+
+					foreach (Match loopMatch in loopCollection) {
+						if (loopMatch.Groups["fileName"].Value.Trim() == Path.GetFileName(filename)) {
+							int loopStart = int.Parse(loopMatch.Groups["loopStart"].Value);
+							int loopEnd = int.Parse(loopMatch.Groups["loopEnd"].Value);
+
+							return new LoopOverride { LoopStart = loopStart, LoopEnd = loopEnd };
 						}
+
 					}
+				} catch (Exception e) {
+					Console.Error.WriteLine("Could not parse line in loop.txt - " + e.Message);
 				}
 			}
 			return null;


### PR DESCRIPTION
Use regex expressions to capture the looping parameters instead of string manipulation. 

- Seems to fix a bug where looping parameters don't apply to some BRSTMs properly